### PR TITLE
Fix typo in README, add links to course

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,4 @@ Not all Bootstrap websites have to look and behave like Bootstrap websites. In t
 
 These files are the project files for the tutsplus.com video training course, “Customizing Bootstrap Components.” Each folder matches a lesson of the course.
 
-**Available on Envato Tuts+ Mat 2016**
+**Available on Envato Tuts+ May 2016**

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-### Envato Tuts+ Course: Customizing Bootstrap Components
+### Envato Tuts+ Course: [Customizing Bootstrap Components](http://webdesign.tutsplus.com/courses/customizing-bootstrap-components)
 #### Instructor: Craig Campbell
 
 Not all Bootstrap websites have to look and behave like Bootstrap websites. In this course, I’ll teach you how to customize Bootstrap components to fit the needs of your site without making it look like every other Bootstrap site out there.
 
 #### Source Files Description:
 
-These files are the project files for the tutsplus.com video training course, “Customizing Bootstrap Components.” Each folder matches a lesson of the course.
+These files are the project files for the tutsplus.com video training course, “[Customizing Bootstrap Components](http://webdesign.tutsplus.com/courses/customizing-bootstrap-components).” Each folder matches a lesson of the course.
 
 **Available on Envato Tuts+ May 2016**


### PR DESCRIPTION
I noticed a minor typo in the readme, and while fixing that, I also added links to the actual course page on TutsPlus.
